### PR TITLE
[Feature] Config overhaul

### DIFF
--- a/src/main/java/com/glektarssza/gtnh_customizer/GTNHCustomizer.java
+++ b/src/main/java/com/glektarssza/gtnh_customizer/GTNHCustomizer.java
@@ -9,6 +9,7 @@ import org.apache.logging.log4j.Logger;
 import net.minecraft.util.ResourceLocation;
 
 import cpw.mods.fml.client.event.ConfigChangedEvent.OnConfigChangedEvent;
+import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.Mod;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
@@ -102,6 +103,8 @@ public class GTNHCustomizer {
         LOGGER.info("Registering mod {} with the Forge event bus...",
             Tags.MOD_NAME);
         MinecraftForge.EVENT_BUS.register(this);
+        // -- OnConfigChangedEvent comes in through here
+        FMLCommonHandler.instance().bus().register(this);
         LOGGER.info("Done pre-initializing {}!", Tags.MOD_NAME);
     }
 
@@ -141,7 +144,7 @@ public class GTNHCustomizer {
      */
     @SubscribeEvent
     public void onConfigChange(OnConfigChangedEvent event) {
-        if (event.modID.equals(Tags.MOD_ID)) {
+        if (event.configID.equalsIgnoreCase(Config.CONFIG_ID.toString())) {
             LOGGER.info("Synchronizing configuration for {}...", Tags.MOD_NAME);
             Config.sync();
         }

--- a/src/main/java/com/glektarssza/gtnh_customizer/commands/RepairCommand.java
+++ b/src/main/java/com/glektarssza/gtnh_customizer/commands/RepairCommand.java
@@ -499,8 +499,9 @@ public class RepairCommand extends CommandBase {
                             look.yCoord * reach, look.zCoord * reach);
                         MovingObjectPosition pos = victim.worldObj
                             .func_147447_a(start, end,
-                                !Config.getRepairCommandIgnoresLiquids(),
-                                Config.getRepairCommandIgnoresLiquids(), false);
+                                !Config.getRepairCommandRaycastIgnoresLiquids(),
+                                Config.getRepairCommandRaycastIgnoresLiquids(),
+                                false);
                         if (pos == null
                             || pos.typeOfHit != MovingObjectType.BLOCK) {
                             throw new WrongUsageException(

--- a/src/main/java/com/glektarssza/gtnh_customizer/config/Config.java
+++ b/src/main/java/com/glektarssza/gtnh_customizer/config/Config.java
@@ -540,13 +540,12 @@ public class Config {
 
     /**
      * Synchronize the mod configuration.
-     *
-     * @param configDir The directory the configuration file will live in.
-     * @param fileName The name of the file to save the configuration to.
      */
     public static void sync() {
-        load();
+        // -- Save the updated config to disk FIRST
         save();
+        // -- THEN reload it into ourselves
+        load();
     }
 
     /**

--- a/src/main/java/com/glektarssza/gtnh_customizer/config/Config.java
+++ b/src/main/java/com/glektarssza/gtnh_customizer/config/Config.java
@@ -440,7 +440,7 @@ public class Config {
         setImmunePlayers(CONFIG_INSTANCE.get(
             ConfigConstants.CATEGORY_GAMEPLAY_PATH,
             ConfigConstants.PROPERTY_GLOBALLY_IMMUNE_PLAYERS_NAME,
-            getGloballyImmunePlayers(),
+            new String[0],
             ConfigConstants.PROPERTY_GLOBALLY_IMMUNE_PLAYERS_COMMENT)
             .setLanguageKey(
                 ConfigConstants.PROPERTY_GLOBALLY_IMMUNE_PLAYERS_LANG_KEY)
@@ -464,7 +464,7 @@ public class Config {
         setTConstructSlimeSaplingBoneMealable(CONFIG_INSTANCE.get(
             ConfigConstants.CATEGORY_GAMEPLAY_TCONSTRUCT_PATH,
             ConfigConstants.PROPERTY_TCONSTRUCT_SLIME_SAPLING_BONE_MEALABLE_NAME,
-            getTConstructSlimeSaplingBoneMealable(),
+            true,
             ConfigConstants.PROPERTY_TCONSTRUCT_SLIME_SAPLING_BONE_MEALABLE_COMMENT)
             .setLanguageKey(
                 ConfigConstants.PROPERTY_TCONSTRUCT_SLIME_SAPLING_BONE_MEALABLE_LANG_KEY)
@@ -484,7 +484,7 @@ public class Config {
         setRepairCommandRaycastIgnoresLiquids(CONFIG_INSTANCE.get(
             ConfigConstants.CATEGORY_COMMAND_PATH,
             ConfigConstants.PROPERTY_REPAIR_COMMAND_RAYCAST_IGNORES_LIQUIDS_NAME,
-            getRepairCommandRaycastIgnoresLiquids(),
+            false,
             ConfigConstants.PROPERTY_REPAIR_COMMAND_RAYCAST_IGNORES_LIQUIDS_COMMENT)
             .setLanguageKey(
                 ConfigConstants.PROPERTY_REPAIR_COMMAND_RAYCAST_IGNORES_LIQUIDS_LANG_KEY)
@@ -494,7 +494,7 @@ public class Config {
         setExtinguishCommandMaxVolume(CONFIG_INSTANCE.get(
             ConfigConstants.CATEGORY_COMMAND_PATH,
             ConfigConstants.PROPERTY_EXTINGUISH_COMMAND_MAX_VOLUME_NAME,
-            getExtinguishCommandMaxVolume(),
+            Integer.MAX_VALUE,
             ConfigConstants.PROPERTY_EXTINGUISH_COMMAND_MAX_VOLUME_COMMENT)
             .setLanguageKey(
                 ConfigConstants.PROPERTY_EXTINGUISH_COMMAND_MAX_VOLUME_LANG_KEY)
@@ -516,7 +516,7 @@ public class Config {
         setVerboseLoggingEnabled(CONFIG_INSTANCE.get(
             ConfigConstants.CATEGORY_DEBUGGING_PATH,
             ConfigConstants.PROPERTY_DEBUG_LOGGING_NAME,
-            getVerboseLoggingEnabled(),
+            false,
             ConfigConstants.PROPERTY_DEBUG_LOGGING_COMMENT)
             .setLanguageKey(ConfigConstants.PROPERTY_DEBUG_LOGGING_LANG_KEY)
             .setRequiresMcRestart(false).setRequiresWorldRestart(false)

--- a/src/main/java/com/glektarssza/gtnh_customizer/config/Config.java
+++ b/src/main/java/com/glektarssza/gtnh_customizer/config/Config.java
@@ -12,13 +12,14 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.UUID;
 import java.util.function.Consumer;
 
 import net.minecraftforge.common.config.ConfigCategory;
 import net.minecraftforge.common.config.Configuration;
 
 import com.glektarssza.gtnh_customizer.GTNHCustomizer;
-import com.glektarssza.gtnh_customizer.config.v5.ConfigConstants;
+import com.glektarssza.gtnh_customizer.config.v6.ConfigConstants;
 import com.glektarssza.gtnh_customizer.utils.ImmutableTuple;
 import com.glektarssza.gtnh_customizer.utils.exceptions.KeyAlreadyExistsException;
 
@@ -26,7 +27,6 @@ import com.glektarssza.gtnh_customizer.utils.exceptions.KeyAlreadyExistsExceptio
  * The main configuration for the mod.
  */
 public class Config {
-
     /**
      * The configuration instance.
      */
@@ -46,9 +46,15 @@ public class Config {
     private static final List<String> globallyImmunePlayers = new ArrayList<String>();
 
     /**
-     * Whether the {@code repair} command ignores liquids.
+     * Whether the {@code repair} command ignores liquids when raycasting to
+     * look for containers to repair items inside of.
      */
     private static boolean repairCommandIgnoresLiquids = false;
+
+    /**
+     * Whether Tinker's Construct Slime Saplings can be bone mealed.
+     */
+    private static boolean tconstructSlimeSaplingsBoneMealable = true;
 
     /**
      * The maximum number of blocks the {@code extinguish} command should
@@ -60,6 +66,11 @@ public class Config {
      * Whether verbose logging is enabled.
      */
     private static boolean verboseLoggingEnabled = false;
+
+    /**
+     * A random UUID which uniquely IDs this run of Minecraft.
+     */
+    public static UUID CONFIG_ID = UUID.randomUUID();
 
     /**
      * Get the globally immune players.
@@ -90,35 +101,81 @@ public class Config {
     }
 
     /**
-     * Get whether the {@code repair} command ignores liquids.
+     * Get whether Tinker's Construct Slime Saplings should be able to be bone
+     * mealed.
      *
-     * @return Whether the {@code repair} command ignores liquids.
+     * @return Whether Tinker's Construct Slime Saplings should be able to be
+     *         bone mealed.
      */
-    public static boolean getRepairCommandIgnoresLiquids() {
+    public static boolean getTConstructSlimeSaplingBoneMealable() {
+        return tconstructSlimeSaplingsBoneMealable;
+    }
+
+    /**
+     * Set whether Tinker's Construct Slime Saplings should be able to be bone
+     * mealed.
+     *
+     * @param value Whether Tinker's Construct Slime Saplings should be able to
+     *        be bone mealed.
+     */
+    public static void setTConstructSlimeSaplingBoneMealable(boolean value) {
+        tconstructSlimeSaplingsBoneMealable = value;
+    }
+
+    /**
+     * Reset whether Tinker's Construct Slime Saplings should be able to be bone
+     * mealed.
+     */
+    public static void resetTConstructSlimeSaplingBoneMealable() {
+        setTConstructSlimeSaplingBoneMealable(false);
+    }
+
+    /**
+     * Toggle whether Tinker's Construct Slime Saplings should be able to be
+     * bone mealed.
+     */
+    public static void toggleTConstructSlimeSaplingBoneMealable() {
+        setTConstructSlimeSaplingBoneMealable(
+            !getTConstructSlimeSaplingBoneMealable());
+    }
+
+    /**
+     * Get whether the {@code repair} command raycast while looking for
+     * containers ignores liquids.
+     *
+     * @return Whether the {@code repair} command raycast while looking for
+     *         containers ignores liquids.
+     */
+    public static boolean getRepairCommandRaycastIgnoresLiquids() {
         return repairCommandIgnoresLiquids;
     }
 
     /**
-     * Set whether the {@code repair} command ignores liquids.
+     * Set whether the {@code repair} command raycast while looking for
+     * containers ignores liquids.
      *
-     * @param value Whether the {@code repair} command ignores liquids.
+     * @param value Whether the {@code repair} command raycast while looking for
+     *        containers ignores liquids.
      */
-    public static void setRepairCommandIgnoresLiquids(boolean value) {
+    public static void setRepairCommandRaycastIgnoresLiquids(boolean value) {
         repairCommandIgnoresLiquids = value;
     }
 
     /**
-     * Reset whether the {@code repair} command ignores liquids.
+     * Reset whether the {@code repair} command raycast while looking for
+     * containers ignores liquids.
      */
-    public static void resetRepairCommandIgnoresLiquids() {
-        setRepairCommandIgnoresLiquids(false);
+    public static void resetRepairCommandRaycastIgnoresLiquids() {
+        setRepairCommandRaycastIgnoresLiquids(false);
     }
 
     /**
-     * Toggle whether the {@code repair} command ignores liquids.
+     * Toggle whether the {@code repair} command raycast while looking for
+     * containers ignores liquids.
      */
-    public static void toggleRepairCommandIgnoresLiquids() {
-        setRepairCommandIgnoresLiquids(!getRepairCommandIgnoresLiquids());
+    public static void toggleRepairCommandRaycastIgnoresLiquids() {
+        setRepairCommandRaycastIgnoresLiquids(
+            !getRepairCommandRaycastIgnoresLiquids());
     }
 
     /**
@@ -238,15 +295,53 @@ public class Config {
             });
         registerMigration(
             com.glektarssza.gtnh_customizer.config.v2.ConfigConstants.CONFIG_VERSION,
-            ConfigConstants.CONFIG_VERSION, (configInstance) -> {
+            com.glektarssza.gtnh_customizer.config.v3.ConfigConstants.CONFIG_VERSION,
+            (configInstance) -> {
                 if (MigrationUtils.hasPropertyByPath(configInstance,
                     com.glektarssza.gtnh_customizer.config.v2.ConfigConstants.PROPERTY_GLOBALLY_IMMUNE_PLAYERS_PATH)) {
                     MigrationUtils.renameProperty(configInstance,
                         com.glektarssza.gtnh_customizer.config.v2.ConfigConstants.PROPERTY_GLOBALLY_IMMUNE_PLAYERS_PATH,
-                        ConfigConstants.PROPERTY_GLOBALLY_IMMUNE_PLAYERS_NAME);
+                        com.glektarssza.gtnh_customizer.config.v3.ConfigConstants.PROPERTY_GLOBALLY_IMMUNE_PLAYERS_NAME);
                 }
             });
-
+        registerMigration(
+            com.glektarssza.gtnh_customizer.config.v5.ConfigConstants.CONFIG_VERSION,
+            com.glektarssza.gtnh_customizer.config.v6.ConfigConstants.CONFIG_VERSION,
+            (configInstance) -> {
+                if (MigrationUtils.hasPropertyByPath(configInstance,
+                    com.glektarssza.gtnh_customizer.config.v5.ConfigConstants.PROPERTY_GLOBALLY_IMMUNE_PLAYERS_PATH)) {
+                    configInstance
+                        .setCategoryComment(
+                            com.glektarssza.gtnh_customizer.config.v6.ConfigConstants.CATEGORY_GAMEPLAY_PATH,
+                            com.glektarssza.gtnh_customizer.config.v6.ConfigConstants.CATEGORY_GAMEPLAY_COMMENT)
+                        .setCategoryLanguageKey(
+                            com.glektarssza.gtnh_customizer.config.v6.ConfigConstants.CATEGORY_GAMEPLAY_PATH,
+                            com.glektarssza.gtnh_customizer.config.v6.ConfigConstants.CATEGORY_GAMEPLAY_LANG_KEY)
+                        .setCategoryRequiresMcRestart(
+                            com.glektarssza.gtnh_customizer.config.v6.ConfigConstants.CATEGORY_GAMEPLAY_PATH,
+                            false)
+                        .setCategoryRequiresMcRestart(
+                            com.glektarssza.gtnh_customizer.config.v6.ConfigConstants.CATEGORY_GAMEPLAY_PATH,
+                            false);
+                    MigrationUtils.moveProperty(configInstance,
+                        com.glektarssza.gtnh_customizer.config.v5.ConfigConstants.PROPERTY_GLOBALLY_IMMUNE_PLAYERS_PATH,
+                        com.glektarssza.gtnh_customizer.config.v6.ConfigConstants.CATEGORY_GAMEPLAY_PATH);
+                    // -- This SHOULD be `true` but let's be safe about things
+                    if (configInstance.getCategory(
+                        com.glektarssza.gtnh_customizer.config.v5.ConfigConstants.CATEGORY_GENERAL_PATH)
+                        .isEmpty()) {
+                        configInstance
+                            .removeCategory(configInstance.getCategory(
+                                com.glektarssza.gtnh_customizer.config.v5.ConfigConstants.CATEGORY_GENERAL_PATH));
+                    }
+                }
+                if (MigrationUtils.hasPropertyByPath(configInstance,
+                    com.glektarssza.gtnh_customizer.config.v5.ConfigConstants.PROPERTY_REPAIR_COMMAND_IGNORES_LIQUIDS_PATH)) {
+                    MigrationUtils.renameProperty(configInstance,
+                        com.glektarssza.gtnh_customizer.config.v5.ConfigConstants.PROPERTY_REPAIR_COMMAND_IGNORES_LIQUIDS_PATH,
+                        com.glektarssza.gtnh_customizer.config.v6.ConfigConstants.PROPERTY_REPAIR_COMMAND_RAYCAST_IGNORES_LIQUIDS_NAME);
+                }
+            });
         if (CONFIG_INSTANCE != null) {
             return;
         }
@@ -331,20 +426,21 @@ public class Config {
             }
         }
         CONFIG_INSTANCE
-            .setCategoryComment(ConfigConstants.CATEGORY_GENERAL_NAME,
-                ConfigConstants.CATEGORY_GENERAL_COMMENT)
-            .setCategoryLanguageKey(ConfigConstants.CATEGORY_GENERAL_NAME,
-                ConfigConstants.CATEGORY_GENERAL_LANG_KEY)
-            .setCategoryRequiresMcRestart(ConfigConstants.CATEGORY_GENERAL_NAME,
+            .setCategoryComment(ConfigConstants.CATEGORY_GAMEPLAY_PATH,
+                ConfigConstants.CATEGORY_GAMEPLAY_COMMENT)
+            .setCategoryLanguageKey(ConfigConstants.CATEGORY_GAMEPLAY_PATH,
+                ConfigConstants.CATEGORY_GAMEPLAY_LANG_KEY)
+            .setCategoryRequiresMcRestart(
+                ConfigConstants.CATEGORY_GAMEPLAY_PATH,
                 false)
-            .setCategoryRequiresMcRestart(ConfigConstants.CATEGORY_GENERAL_NAME,
+            .setCategoryRequiresMcRestart(
+                ConfigConstants.CATEGORY_GAMEPLAY_PATH,
                 false);
 
         setImmunePlayers(CONFIG_INSTANCE.get(
-            ConfigConstants.CATEGORY_GENERAL_PATH,
+            ConfigConstants.CATEGORY_GAMEPLAY_PATH,
             ConfigConstants.PROPERTY_GLOBALLY_IMMUNE_PLAYERS_NAME,
-            globallyImmunePlayers
-                .toArray(new String[globallyImmunePlayers.size()]),
+            getGloballyImmunePlayers(),
             ConfigConstants.PROPERTY_GLOBALLY_IMMUNE_PLAYERS_COMMENT)
             .setLanguageKey(
                 ConfigConstants.PROPERTY_GLOBALLY_IMMUNE_PLAYERS_LANG_KEY)
@@ -352,29 +448,53 @@ public class Config {
             .getStringList());
 
         CONFIG_INSTANCE
-            .setCategoryComment(ConfigConstants.CATEGORY_COMMAND_NAME,
-                ConfigConstants.CATEGORY_COMMAND_COMMENT)
-            .setCategoryLanguageKey(ConfigConstants.CATEGORY_COMMAND_NAME,
-                ConfigConstants.CATEGORY_COMMAND_LANG_KEY)
-            .setCategoryRequiresMcRestart(ConfigConstants.CATEGORY_COMMAND_NAME,
+            .setCategoryComment(
+                ConfigConstants.CATEGORY_GAMEPLAY_TCONSTRUCT_PATH,
+                ConfigConstants.CATEGORY_GAMEPLAY_TCONSTRUCT_COMMENT)
+            .setCategoryLanguageKey(
+                ConfigConstants.CATEGORY_GAMEPLAY_TCONSTRUCT_PATH,
+                ConfigConstants.CATEGORY_GAMEPLAY_TCONSTRUCT_LANG_KEY)
+            .setCategoryRequiresMcRestart(
+                ConfigConstants.CATEGORY_GAMEPLAY_TCONSTRUCT_PATH,
                 false)
-            .setCategoryRequiresMcRestart(ConfigConstants.CATEGORY_COMMAND_NAME,
+            .setCategoryRequiresMcRestart(
+                ConfigConstants.CATEGORY_GAMEPLAY_TCONSTRUCT_PATH,
                 false);
 
-        setRepairCommandIgnoresLiquids(CONFIG_INSTANCE.get(
-            ConfigConstants.CATEGORY_COMMAND_PATH,
-            ConfigConstants.PROPERTY_REPAIR_COMMAND_IGNORES_LIQUIDS_NAME,
-            repairCommandIgnoresLiquids,
-            ConfigConstants.PROPERTY_REPAIR_COMMAND_IGNORES_LIQUIDS_COMMENT)
+        setTConstructSlimeSaplingBoneMealable(CONFIG_INSTANCE.get(
+            ConfigConstants.CATEGORY_GAMEPLAY_TCONSTRUCT_PATH,
+            ConfigConstants.PROPERTY_TCONSTRUCT_SLIME_SAPLING_BONE_MEALABLE_NAME,
+            getTConstructSlimeSaplingBoneMealable(),
+            ConfigConstants.PROPERTY_TCONSTRUCT_SLIME_SAPLING_BONE_MEALABLE_COMMENT)
             .setLanguageKey(
-                ConfigConstants.PROPERTY_REPAIR_COMMAND_IGNORES_LIQUIDS_LANG_KEY)
+                ConfigConstants.PROPERTY_TCONSTRUCT_SLIME_SAPLING_BONE_MEALABLE_LANG_KEY)
+            .setRequiresMcRestart(false).setRequiresWorldRestart(false)
+            .getBoolean());
+
+        CONFIG_INSTANCE
+            .setCategoryComment(ConfigConstants.CATEGORY_COMMAND_PATH,
+                ConfigConstants.CATEGORY_COMMAND_COMMENT)
+            .setCategoryLanguageKey(ConfigConstants.CATEGORY_COMMAND_PATH,
+                ConfigConstants.CATEGORY_COMMAND_LANG_KEY)
+            .setCategoryRequiresMcRestart(ConfigConstants.CATEGORY_COMMAND_PATH,
+                false)
+            .setCategoryRequiresMcRestart(ConfigConstants.CATEGORY_COMMAND_PATH,
+                false);
+
+        setRepairCommandRaycastIgnoresLiquids(CONFIG_INSTANCE.get(
+            ConfigConstants.CATEGORY_COMMAND_PATH,
+            ConfigConstants.PROPERTY_REPAIR_COMMAND_RAYCAST_IGNORES_LIQUIDS_NAME,
+            getRepairCommandRaycastIgnoresLiquids(),
+            ConfigConstants.PROPERTY_REPAIR_COMMAND_RAYCAST_IGNORES_LIQUIDS_COMMENT)
+            .setLanguageKey(
+                ConfigConstants.PROPERTY_REPAIR_COMMAND_RAYCAST_IGNORES_LIQUIDS_LANG_KEY)
             .setRequiresMcRestart(false).setRequiresWorldRestart(false)
             .getBoolean());
 
         setExtinguishCommandMaxVolume(CONFIG_INSTANCE.get(
             ConfigConstants.CATEGORY_COMMAND_PATH,
             ConfigConstants.PROPERTY_EXTINGUISH_COMMAND_MAX_VOLUME_NAME,
-            extinguishCommandMaxVolume,
+            getExtinguishCommandMaxVolume(),
             ConfigConstants.PROPERTY_EXTINGUISH_COMMAND_MAX_VOLUME_COMMENT)
             .setLanguageKey(
                 ConfigConstants.PROPERTY_EXTINGUISH_COMMAND_MAX_VOLUME_LANG_KEY)
@@ -396,7 +516,7 @@ public class Config {
         setVerboseLoggingEnabled(CONFIG_INSTANCE.get(
             ConfigConstants.CATEGORY_DEBUGGING_PATH,
             ConfigConstants.PROPERTY_DEBUG_LOGGING_NAME,
-            verboseLoggingEnabled,
+            getVerboseLoggingEnabled(),
             ConfigConstants.PROPERTY_DEBUG_LOGGING_COMMENT)
             .setLanguageKey(ConfigConstants.PROPERTY_DEBUG_LOGGING_LANG_KEY)
             .setRequiresMcRestart(false).setRequiresWorldRestart(false)

--- a/src/main/java/com/glektarssza/gtnh_customizer/config/ConfigGui.java
+++ b/src/main/java/com/glektarssza/gtnh_customizer/config/ConfigGui.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.client.resources.I18n;
 
 import cpw.mods.fml.client.config.GuiConfig;
 import cpw.mods.fml.client.config.IConfigElement;
@@ -34,9 +35,10 @@ public class ConfigGui extends GuiConfig {
                 .map((category) -> new ConfigElement<ConfigCategory>(category))
                 .collect(Collectors.toList()),
             Tags.MOD_ID,
+            Config.CONFIG_ID.toString(),
             false,
             false,
-            String.format("%s.cfg", Tags.MOD_ID));
+            I18n.format("gtnh_customizer.config.ui.title", Tags.MOD_ID));
     }
 
     @Override

--- a/src/main/java/com/glektarssza/gtnh_customizer/config/MigrationUtils.java
+++ b/src/main/java/com/glektarssza/gtnh_customizer/config/MigrationUtils.java
@@ -903,7 +903,7 @@ public final class MigrationUtils {
         Property property = getPropertyByPath(instance, path, pathSeparators);
         ConfigCategory oldCategory = getPropertyParentCategoryByPath(instance,
             path, pathSeparators);
-        ConfigCategory newCategory = getPropertyParentCategoryByPath(instance,
+        ConfigCategory newCategory = getCategoryByPath(instance,
             newCategoryPath, pathSeparators);
         if (newCategory.containsKey(property.getName())) {
             throw new KeyAlreadyExistsException(String.format(

--- a/src/main/java/com/glektarssza/gtnh_customizer/config/v6/ConfigConstants.java
+++ b/src/main/java/com/glektarssza/gtnh_customizer/config/v6/ConfigConstants.java
@@ -1,0 +1,253 @@
+package com.glektarssza.gtnh_customizer.config.v6;
+
+import net.minecraftforge.common.config.Configuration;
+
+public class ConfigConstants {
+    /**
+     * The version of the configuration format.
+     */
+    public static final String CONFIG_VERSION = "6";
+
+    /**
+     * The gameplay tweaks configuration category name.
+     */
+    public static final String CATEGORY_GAMEPLAY_NAME = "gameplay";
+
+    /**
+     * The gameplay tweaks configuration category path.
+     */
+    public static final String CATEGORY_GAMEPLAY_PATH = CATEGORY_GAMEPLAY_NAME;
+
+    /**
+     * The gameplay tweaks configuration category comment.
+     */
+    public static final String CATEGORY_GAMEPLAY_COMMENT = "Gameplay-related tweaks";
+
+    /**
+     * The gameplay tweaks configuration category language key.
+     */
+    public static final String CATEGORY_GAMEPLAY_LANG_KEY = String
+        .format("gtnh_customizer%sconfig%scategory_%s",
+            Configuration.CATEGORY_SPLITTER,
+            Configuration.CATEGORY_SPLITTER,
+            CATEGORY_GAMEPLAY_NAME);
+
+    /**
+     * The globally immune players property name.
+     */
+    public static final String PROPERTY_GLOBALLY_IMMUNE_PLAYERS_NAME = "globally_immune_players";
+
+    /**
+     * The globally immune players property path.
+     */
+    public static final String PROPERTY_GLOBALLY_IMMUNE_PLAYERS_PATH = String
+        .format("%s%s%s",
+            CATEGORY_GAMEPLAY_PATH,
+            Configuration.CATEGORY_SPLITTER,
+            PROPERTY_GLOBALLY_IMMUNE_PLAYERS_NAME);
+
+    /**
+     * The globally immune players property comment.
+     */
+    public static final String PROPERTY_GLOBALLY_IMMUNE_PLAYERS_COMMENT = "A list of players who are globally immune to being targeted.";
+
+    /**
+     * The globally immune players property language key.
+     */
+    public static final String PROPERTY_GLOBALLY_IMMUNE_PLAYERS_LANG_KEY = String
+        .format("%s%s%s",
+            CATEGORY_GAMEPLAY_LANG_KEY,
+            Configuration.CATEGORY_SPLITTER,
+            PROPERTY_GLOBALLY_IMMUNE_PLAYERS_NAME);
+
+    /**
+     * The Tinker's Construct gameplay tweaks configuration category name.
+     */
+    public static final String CATEGORY_GAMEPLAY_TCONSTRUCT_NAME = "tconstruct";
+
+    /**
+     * The Tinker's Construct tweaks configuration category path.
+     */
+    public static final String CATEGORY_GAMEPLAY_TCONSTRUCT_PATH = String
+        .format(
+            "%s%s%s",
+            CATEGORY_GAMEPLAY_PATH,
+            Configuration.CATEGORY_SPLITTER,
+            CATEGORY_GAMEPLAY_TCONSTRUCT_NAME);
+
+    /**
+     * The Tinker's Construct tweaks configuration category comment.
+     */
+    public static final String CATEGORY_GAMEPLAY_TCONSTRUCT_COMMENT = "Tinker's Construct gameplay-related tweaks";
+
+    /**
+     * The Tinker's Construct tweaks configuration category language key.
+     */
+    public static final String CATEGORY_GAMEPLAY_TCONSTRUCT_LANG_KEY = String
+        .format("%s%scategory_%s",
+            CATEGORY_GAMEPLAY_LANG_KEY,
+            Configuration.CATEGORY_SPLITTER,
+            CATEGORY_GAMEPLAY_TCONSTRUCT_NAME);
+
+    /**
+     * The allow slime sapling bone mealing property name.
+     */
+    public static final String PROPERTY_TCONSTRUCT_SLIME_SAPLING_BONE_MEALABLE_NAME = "slime_sapling_bone_mealable";
+
+    /**
+     * The allow slime sapling bone mealing property path.
+     */
+    public static final String PROPERTY_TCONSTRUCT_SLIME_SAPLING_BONE_MEALABLE_PATH = String
+        .format("%s%s%s",
+            CATEGORY_GAMEPLAY_TCONSTRUCT_PATH,
+            Configuration.CATEGORY_SPLITTER,
+            PROPERTY_TCONSTRUCT_SLIME_SAPLING_BONE_MEALABLE_NAME);
+
+    /**
+     * The allow slime sapling bone mealing property comment.
+     */
+    public static final String PROPERTY_TCONSTRUCT_SLIME_SAPLING_BONE_MEALABLE_COMMENT = "Whether to allow Tinker's Construct Slime Saplings to be bone mealed.";
+
+    /**
+     * The allow slime sapling bone mealing property language key.
+     */
+    public static final String PROPERTY_TCONSTRUCT_SLIME_SAPLING_BONE_MEALABLE_LANG_KEY = String
+        .format("%s%s%s",
+            CATEGORY_GAMEPLAY_TCONSTRUCT_LANG_KEY,
+            Configuration.CATEGORY_SPLITTER,
+            PROPERTY_TCONSTRUCT_SLIME_SAPLING_BONE_MEALABLE_NAME);
+
+    /**
+     * The command configuration category name.
+     */
+    public static final String CATEGORY_COMMAND_NAME = "command";
+
+    /**
+     * The command configuration category path.
+     */
+    public static final String CATEGORY_COMMAND_PATH = CATEGORY_COMMAND_NAME;
+
+    /**
+     * The command configuration category comment.
+     */
+    public static final String CATEGORY_COMMAND_COMMENT = "Command settings";
+
+    /**
+     * The command configuration category language key.
+     */
+    public static final String CATEGORY_COMMAND_LANG_KEY = String
+        .format("gtnh_customizer%sconfig%scategory_%s",
+            Configuration.CATEGORY_SPLITTER,
+            Configuration.CATEGORY_SPLITTER,
+            CATEGORY_COMMAND_PATH);
+
+    /**
+     * Whether the {@code repair} command raycast while looking for containers
+     * should ignore liquids property name.
+     */
+    public static final String PROPERTY_REPAIR_COMMAND_RAYCAST_IGNORES_LIQUIDS_NAME = "repair_raycast_ignores_liquids";
+
+    /**
+     * Whether the {@code repair} command raycast while looking for containers
+     * should ignore liquids property path.
+     */
+    public static final String PROPERTY_REPAIR_COMMAND_RAYCAST_IGNORES_LIQUIDS_PATH = String
+        .format("%s%s%s", CATEGORY_COMMAND_PATH,
+            Configuration.CATEGORY_SPLITTER,
+            PROPERTY_REPAIR_COMMAND_RAYCAST_IGNORES_LIQUIDS_NAME);
+
+    /**
+     * Whether the {@code repair} command raycast while looking for containers
+     * should ignore liquids property language key.
+     */
+    public static final String PROPERTY_REPAIR_COMMAND_RAYCAST_IGNORES_LIQUIDS_LANG_KEY = String
+        .format("%s%s%s", CATEGORY_COMMAND_LANG_KEY,
+            Configuration.CATEGORY_SPLITTER,
+            PROPERTY_REPAIR_COMMAND_RAYCAST_IGNORES_LIQUIDS_NAME);
+
+    /**
+     * Whether the {@code repair} command raycast while looking for containers
+     * should ignore liquids property comment.
+     */
+    public static final String PROPERTY_REPAIR_COMMAND_RAYCAST_IGNORES_LIQUIDS_COMMENT = "Whether the 'repair' command ignores liquids when raycasting to look for containers to repair items inside of.";
+
+    /**
+     * The maximum number of blocks the {@code extinguish} command should
+     * process property name.
+     */
+    public static final String PROPERTY_EXTINGUISH_COMMAND_MAX_VOLUME_NAME = "extinguish_max_volume";
+
+    /**
+     * The maximum number of blocks the {@code extinguish} command should
+     * process property path.
+     */
+    public static final String PROPERTY_EXTINGUISH_COMMAND_MAX_VOLUME_PATH = String
+        .format("%s%s%s", CATEGORY_COMMAND_PATH,
+            Configuration.CATEGORY_SPLITTER,
+            PROPERTY_EXTINGUISH_COMMAND_MAX_VOLUME_NAME);
+
+    /**
+     * Whether the {@code repair} command should ignore liquids property
+     * language key.
+     */
+    public static final String PROPERTY_EXTINGUISH_COMMAND_MAX_VOLUME_LANG_KEY = String
+        .format("%s%s%s", CATEGORY_COMMAND_LANG_KEY,
+            Configuration.CATEGORY_SPLITTER,
+            PROPERTY_EXTINGUISH_COMMAND_MAX_VOLUME_NAME);
+
+    /**
+     * The maximum number of blocks the {@code extinguish} command should
+     * process property comment.
+     */
+    public static final String PROPERTY_EXTINGUISH_COMMAND_MAX_VOLUME_COMMENT = "The maximum number of blocks the 'extinguish' command will process.";
+
+    /**
+     * The debugging configuration category name.
+     */
+    public static final String CATEGORY_DEBUGGING_NAME = "debugging";
+
+    /**
+     * The debugging configuration category path.
+     */
+    public static final String CATEGORY_DEBUGGING_PATH = CATEGORY_DEBUGGING_NAME;
+
+    /**
+     * The debugging configuration category comment.
+     */
+    public static final String CATEGORY_DEBUGGING_COMMENT = "Debugging settings";
+
+    /**
+     * The debugging configuration category language key.
+     */
+    public static final String CATEGORY_DEBUGGING_LANG_KEY = String
+        .format("gtnh_customizer%sconfig%scategory_%s",
+            Configuration.CATEGORY_SPLITTER,
+            Configuration.CATEGORY_SPLITTER,
+            CATEGORY_DEBUGGING_PATH);
+
+    /**
+     * The verbose logging property name.
+     */
+    public static final String PROPERTY_DEBUG_LOGGING_NAME = "verbose_logging";
+
+    /**
+     * The verbose logging property path.
+     */
+    public static final String PROPERTY_DEBUG_LOGGING_PATH = String
+        .format("%s%s%s", CATEGORY_DEBUGGING_PATH,
+            Configuration.CATEGORY_SPLITTER,
+            PROPERTY_DEBUG_LOGGING_NAME);
+
+    /**
+     * The verbose logging property comment.
+     */
+    public static final String PROPERTY_DEBUG_LOGGING_COMMENT = "Enable verbose logging.";
+
+    /**
+     * The verbose logging property language key.
+     */
+    public static final String PROPERTY_DEBUG_LOGGING_LANG_KEY = String
+        .format("%s%s%s", CATEGORY_DEBUGGING_LANG_KEY,
+            Configuration.CATEGORY_SPLITTER,
+            PROPERTY_DEBUG_LOGGING_NAME);
+}

--- a/src/main/java/com/glektarssza/gtnh_customizer/mixins/late/tconstruct/SlimeSaplingMixin.java
+++ b/src/main/java/com/glektarssza/gtnh_customizer/mixins/late/tconstruct/SlimeSaplingMixin.java
@@ -7,6 +7,8 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
+import com.glektarssza.gtnh_customizer.config.Config;
+
 import tconstruct.blocks.slime.SlimeSapling;
 
 /**
@@ -16,6 +18,9 @@ import tconstruct.blocks.slime.SlimeSapling;
 public class SlimeSaplingMixin {
     @Redirect(method = "Ltconstruct/blocks/slime/SlimeSapling;boneFertilize(Lnet/minecraft/world/World;IIILjava/util/Random;Lnet/minecraft/entity/player/EntityPlayer;)Z", at = @At(value = "FIELD", target = "Lnet/minecraft/entity/player/PlayerCapabilities;isCreativeMode:Z", opcode = Opcodes.GETFIELD))
     private boolean overwriteGetPlayerIsCreative(PlayerCapabilities self) {
-        return true;
+        if (Config.getTConstructSlimeSaplingBoneMealable()) {
+            return true;
+        }
+        return self.isCreativeMode;
     }
 }

--- a/src/main/resources/assets/gtnh_customizer/lang/en_US.lang
+++ b/src/main/resources/assets/gtnh_customizer/lang/en_US.lang
@@ -1,14 +1,27 @@
+# Configuration GUI
+gtnh_customizer.config.ui.title=Configuration - %s
+
 # Configuration Categories - General
 gtnh_customizer.config.category_general=General Settings
 gtnh_customizer.config.category_general.tooltip=Settings relating to general functionality.
-gtnh_customizer.config.category_general.globally_immune_players=Globally Immune Players
-gtnh_customizer.config.category_general.globally_immune_players.tooltip=A list of players who are globally immune to being targeted.
+
+# Configuration Categories - Gameplay Tweaks
+gtnh_customizer.config.category_gameplay=Gameplay Tweaks
+gtnh_customizer.config.category_gameplay.tooltip=Tweaks to gameplay.
+gtnh_customizer.config.category_gameplay.globally_immune_players=Globally Immune Players
+gtnh_customizer.config.category_gameplay.globally_immune_players.tooltip=A list of players who are globally immune to being targeted.
+
+# Configuration Categories - Gameplay Tweaks - Tinker's Construct
+gtnh_customizer.config.category_gameplay.category_tconstruct=Tinker's Construct
+gtnh_customizer.config.category_gameplay.category_tconstruct.tooltip=Tinker's Construct-related gameplay tweaks
+gtnh_customizer.config.category_gameplay.category_tconstruct.slime_sapling_bone_mealable=Slime Sapling Bone Mealable
+gtnh_customizer.config.category_gameplay.category_tconstruct.slime_sapling_bone_mealable.tooltip=Whether to allow Tinker's Construct Slime Saplings to be bone mealed.
 
 # Configuration Categories - Commands
 gtnh_customizer.config.category_command=Command Settings
 gtnh_customizer.config.category_command.tooltip=Settings relating to command functionality.
 gtnh_customizer.config.category_command.repair_ignores_liquids=Repair Command Ignores Liquids
-gtnh_customizer.config.category_command.repair_ignores_liquids.tooltip=Whether the 'repair' command ignores liquids when looking for contains to repair items inside of.
+gtnh_customizer.config.category_command.repair_ignores_liquids.tooltip=Whether the 'repair' command ignores liquids when raycasting to look for containers to repair items inside of.
 gtnh_customizer.config.category_command.extinguish_max_volume=Extinguish Max Volume
 gtnh_customizer.config.category_command.extinguish_max_volume.tooltip=The maximum number of blocks the 'extinguish' command will process.
 


### PR DESCRIPTION
* Refactored how language keys work.
* Moved gameplay-related tweaks into subcategories per feature type/mod.
* Added setting controlling slime sapling bone meal support.
* Fixed changing settings not taking hold immediately in single player worlds despite saying it's supported.