### PR TITLE
[Feature] Fall back to in-hand item if block does not have a valid tile entity associated with it when using `/nbtedit` command

### DIFF
--- a/src/main/java/com/glektarssza/gtnh_customizer/mixins/late/serverutilities/MessageEditNBTRequestMixin.java
+++ b/src/main/java/com/glektarssza/gtnh_customizer/mixins/late/serverutilities/MessageEditNBTRequestMixin.java
@@ -5,7 +5,6 @@ import com.llamalad7.mixinextras.sugar.ref.LocalRef;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.util.MovingObjectPosition;
-import net.minecraft.util.MovingObjectPosition.MovingObjectType;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
@@ -33,10 +32,23 @@ public class MessageEditNBTRequestMixin {
         if (ray.get() == null) {
             return;
         }
-        if (ray.get().typeOfHit == MovingObjectType.MISS
-            && Minecraft.getMinecraft().thePlayer.inventory
-                .getCurrentItem() != null) {
-            ClientUtils.execClientCommand("/nbtedit item");
+        switch (ray.get().typeOfHit) {
+            case BLOCK:
+                if (Minecraft
+                    .getMinecraft().theWorld.getTileEntity(ray.get().blockX,
+                        ray.get().blockY, ray.get().blockZ) != null) {
+                    // -- Block has a valid tile entity attached, do NOT fall
+                    // -- through to the "miss" case
+                    break;
+                }
+                // -- Block had no tile entity, treat it as a "miss"
+            case MISS:
+                if (Minecraft.getMinecraft().thePlayer.inventory
+                    .getCurrentItem() != null) {
+                    ClientUtils.execClientCommand("/nbtedit item");
+                }
+            default:
+                // -- Do nothing
         }
     }
 }


### PR DESCRIPTION
Really just a small quality of life feature.

### Current Behavior ###

If the ray cast for the Server Utilities `/nbtedit` command comes back as either a miss or a block but the block has no tile entity attached to it and the player is holding an item in their main hand then report an error that the block has no tile entity.

### Updated Behavior ###

If the ray cast for the Server Utilities `/nbtedit` command comes back as either a miss or a block but the block has no tile entity attached to it and the player is holding an item in their main hand then begin editing that item.
