### PR TITLE
[Feature] Key binding support and more commands for NBT edit command

### DIFF
--- a/forgeUpdateManifest.json
+++ b/forgeUpdateManifest.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://github.com/glektarssza/minecraft-gtnh-customizer",
     "1.7.10": {
-        "0.11.0": "* Fall back to in-hand item if block has no tile entity when calling '/nbtedit'.\n * Add key bindings.",
+        "0.11.0": "* Fall back to in-hand item if block has no tile entity when calling '/nbtedit'.\n * Support a shortcut key to delete the selected NBT tag inside the '/nbtedit' command'.\n * Add key bindings.",
         "0.10.0": "* Patch ServerUtilities' '/nbtedit' command to let you use 'numpad enter' to submit your changes.",
         "0.9.0": "* Patch ServerUtilities' '/nbtedit' command to edit the in-hand item (if present) if the in-world ray cast doesn't hit anything.",
         "0.8.0": "* Added the ability to bone meal Thaumcraft saplings.",

--- a/forgeUpdateManifest.json
+++ b/forgeUpdateManifest.json
@@ -1,10 +1,11 @@
 {
     "homepage": "https://github.com/glektarssza/minecraft-gtnh-customizer",
     "1.7.10": {
+        "0.11.0": "* Fall back to in-hand item if block has no tile entity when calling '/nbtedit'.\n * Add key bindings.",
         "0.10.0": "* Patch ServerUtilities' '/nbtedit' command to let you use 'numpad enter' to submit your changes.",
         "0.9.0": "* Patch ServerUtilities' '/nbtedit' command to edit the in-hand item (if present) if the in-world ray cast doesn't hit anything.",
         "0.8.0": "* Added the ability to bone meal Thaumcraft saplings.",
-        "0.7.0": "* Fixed changing configs while single player world is running not taking.\nBig config overhaul, moved gameplay-related configs into their own sections.\nMoved Tinker's Construct-related config items into a sub-section of gameplay config items.\nTinker's Construct Slime Sapling bone mealing can now be toggled on/off in the settings.",
+        "0.7.0": "* Fixed changing configs while single player world is running not taking.\n * Big config overhaul, moved gameplay-related configs into their own sections.\n * Moved Tinker's Construct-related config items into a sub-section of gameplay config items.\n * Tinker's Construct Slime Sapling bone mealing can now be toggled on/off in the settings.",
         "0.6.3": "* Fixed repair command not applying to Tinker's and Gregtech tools.",
         "0.6.2": "* Fixed reload command not working properly on servers.",
         "0.6.1": "* Fixed a bad render distance access on servers in the extinguish command.",
@@ -22,7 +23,7 @@
         "0.2.0": "* Added ability to customize Xaero's teleport command.",
         "0.1.2": "* Fixed teleport command not respecting coordinates.",
         "0.1.1": "* Fixed config migrations.",
-        "0.1.0": "* Updated several dependencies.\n* Added a cross-dimension teleport command.\n* Changed logo.\n* Ported existing code from old repository.",
+        "0.1.0": "* Updated several dependencies.\n * Added a cross-dimension teleport command.\n * Changed logo.\n * Ported existing code from old repository.",
         "0.0.0": "Initial release."
     },
     "promos": {

--- a/src/main/java/com/glektarssza/gtnh_customizer/GTNHCustomizer.java
+++ b/src/main/java/com/glektarssza/gtnh_customizer/GTNHCustomizer.java
@@ -44,7 +44,7 @@ public class GTNHCustomizer {
     /**
      * The logger to use for the mod.
      */
-    public static Logger LOGGER;
+    private static Logger logger;
 
     /**
      * The maximum number of times to emit a warning before silencing it.
@@ -61,6 +61,10 @@ public class GTNHCustomizer {
      */
     @Mod.Instance
     public static GTNHCustomizer instance;
+
+    public static Logger getLogger() {
+        return logger;
+    }
 
     /**
      * Check if a given warning category should be emitted.
@@ -84,7 +88,7 @@ public class GTNHCustomizer {
         WARNING_LIMIT_TRACKER.putIfAbsent(category, WARNING_EMIT_LIMIT);
         int limit = WARNING_LIMIT_TRACKER.compute(category, (_k, v) -> v - 1);
         if (limit <= 0) {
-            LOGGER.warn(
+            logger.warn(
                 String.format(
                     "Too many identical warnings logged for category \"%s\"! Silencing further warnings on this issue!",
                     category));
@@ -98,18 +102,18 @@ public class GTNHCustomizer {
      */
     @Mod.EventHandler
     public void onPreInit(FMLPreInitializationEvent event) {
-        LOGGER = event.getModLog();
-        LOGGER.info("Pre-initializing {}...", Tags.MOD_NAME);
+        logger = event.getModLog();
+        logger.info("Pre-initializing {}...", Tags.MOD_NAME);
         configDir = event.getModConfigurationDirectory();
         Config.init(configDir, String.format("%s.cfg", Tags.MOD_ID));
-        LOGGER.info("Synchronizing configuration for {}...", Tags.MOD_NAME);
+        logger.info("Synchronizing configuration for {}...", Tags.MOD_NAME);
         Config.sync();
-        LOGGER.info("Registering mod {} with the Forge event bus...",
+        logger.info("Registering mod {} with the Forge event bus...",
             Tags.MOD_NAME);
         MinecraftForge.EVENT_BUS.register(this);
         // -- OnConfigChangedEvent comes in through here
         FMLCommonHandler.instance().bus().register(this);
-        LOGGER.info("Done pre-initializing {}!", Tags.MOD_NAME);
+        logger.info("Done pre-initializing {}!", Tags.MOD_NAME);
     }
 
     /**
@@ -119,9 +123,10 @@ public class GTNHCustomizer {
      */
     @Mod.EventHandler
     public void onInit(FMLInitializationEvent event) {
-        LOGGER.info("Initializing {}...", Tags.MOD_NAME);
-        // -- No initialization code... Yet
-        LOGGER.info("Done initializing {}!", Tags.MOD_NAME);
+        logger.info("Initializing {}...", Tags.MOD_NAME);
+        logger.info("Registering key bindings for {}...", Tags.MOD_NAME);
+        KeyBindings.registerKeybinds();
+        logger.info("Done initializing {}!", Tags.MOD_NAME);
     }
 
     /**
@@ -131,14 +136,14 @@ public class GTNHCustomizer {
      */
     @Mod.EventHandler
     public void onServerStarting(FMLServerStartingEvent event) {
-        LOGGER.info("Handling server about to start...");
-        LOGGER.info("Registering custom commands...");
+        logger.info("Handling server about to start...");
+        logger.info("Registering custom commands...");
         event.registerServerCommand(new TeleportCrossDimensionCommand());
         event.registerServerCommand(new ListDimensionsCommand());
         event.registerServerCommand(new RepairCommand());
         event.registerServerCommand(new ExtinguishCommand());
-        LOGGER.info("Done registering custom commands!");
-        LOGGER.info("Done handling server about to start!");
+        logger.info("Done registering custom commands!");
+        logger.info("Done handling server about to start!");
     }
 
     /**
@@ -149,7 +154,7 @@ public class GTNHCustomizer {
     @SubscribeEvent
     public void onConfigChange(OnConfigChangedEvent event) {
         if (event.configID.equalsIgnoreCase(Config.CONFIG_ID.toString())) {
-            LOGGER.info("Synchronizing configuration for {}...", Tags.MOD_NAME);
+            logger.info("Synchronizing configuration for {}...", Tags.MOD_NAME);
             Config.sync();
         }
     }

--- a/src/main/java/com/glektarssza/gtnh_customizer/KeyBindings.java
+++ b/src/main/java/com/glektarssza/gtnh_customizer/KeyBindings.java
@@ -1,0 +1,85 @@
+package com.glektarssza.gtnh_customizer;
+
+import org.lwjgl.input.Keyboard;
+
+import net.minecraft.client.settings.KeyBinding;
+
+import cpw.mods.fml.client.registry.ClientRegistry;
+
+public class KeyBindings {
+    /**
+     * The keybinding for deleting a NBT tag inside the Server Utilities
+     * {@code /nbtedit} command.
+     */
+    public static final KeyBinding DELETE_NBT_TAG = new KeyBinding(
+        "gtnh_customizer.keybindings.serverutilities.delete_nbt_tag",
+        Keyboard.KEY_DELETE,
+        "key.categories.gtnh_customizer");
+
+    /**
+     * The keybinding for accepting an the edits to some NBT data inside the
+     * Server Utilities {@code /nbtedit} command.
+     */
+    public static final KeyBinding ACCEPT_NBT_EDITS = new KeyBinding(
+        "gtnh_customizer.keybindings.serverutilities.accept_nbt_edits",
+        Keyboard.KEY_RETURN,
+        "key.categories.gtnh_customizer");
+
+    /**
+     * The alternate keybinding for accepting an the edits to some NBT data
+     * inside the Server Utilities {@code /nbtedit} command.
+     */
+    public static final KeyBinding ACCEPT_NBT_EDITS_ALT = new KeyBinding(
+        "gtnh_customizer.keybindings.serverutilities.accept_nbt_edits_alt",
+        Keyboard.KEY_NUMPADENTER,
+        "key.categories.gtnh_customizer");
+
+    /**
+     * The keybinding for canceling the the edits to some NBT data inside the
+     * Server Utilities {@code /nbtedit} command.
+     */
+    public static final KeyBinding CANCEL_NBT_EDITS = new KeyBinding(
+        "gtnh_customizer.keybindings.serverutilities.cancel_nbt_edits",
+        Keyboard.KEY_ESCAPE,
+        "key.categories.gtnh_customizer");
+
+    /**
+     * The keybinding for accepting an editted NBT value inside the Server
+     * Utilities {@code /nbtedit} command.
+     */
+    public static final KeyBinding ACCEPT_NBT_VALUE_CHANGE = new KeyBinding(
+        "gtnh_customizer.keybindings.serverutilities.accept_nbt_value_change",
+        Keyboard.KEY_RETURN,
+        "key.categories.gtnh_customizer");
+
+    /**
+     * The alternate keybinding for accepting the editing of a NBT value inside
+     * the Server Utilities {@code /nbtedit} command.
+     */
+    public static final KeyBinding ACCEPT_NBT_VALUE_CHANGE_ALT = new KeyBinding(
+        "gtnh_customizer.keybindings.serverutilities.accept_nbt_value_change_alt",
+        Keyboard.KEY_NUMPADENTER,
+        "key.categories.gtnh_customizer");
+
+    /**
+     * The keybinding for canceling the editing of a NBT value inside the Server
+     * Utilities {@code /nbtedit} command.
+     */
+    public static final KeyBinding CANCEL_NBT_VALUE_CHANGE = new KeyBinding(
+        "gtnh_customizer.keybindings.serverutilities.cancel_nbt_value_change",
+        Keyboard.KEY_RETURN,
+        "key.categories.gtnh_customizer");
+
+    /**
+     * Register this mod's key bindings.
+     */
+    public static void registerKeybinds() {
+        ClientRegistry.registerKeyBinding(DELETE_NBT_TAG);
+        ClientRegistry.registerKeyBinding(ACCEPT_NBT_EDITS);
+        ClientRegistry.registerKeyBinding(ACCEPT_NBT_EDITS_ALT);
+        ClientRegistry.registerKeyBinding(CANCEL_NBT_EDITS);
+        ClientRegistry.registerKeyBinding(ACCEPT_NBT_VALUE_CHANGE);
+        ClientRegistry.registerKeyBinding(ACCEPT_NBT_VALUE_CHANGE_ALT);
+        ClientRegistry.registerKeyBinding(CANCEL_NBT_VALUE_CHANGE);
+    }
+}

--- a/src/main/java/com/glektarssza/gtnh_customizer/config/Config.java
+++ b/src/main/java/com/glektarssza/gtnh_customizer/config/Config.java
@@ -457,48 +457,49 @@ public class Config {
      */
     public static void load() {
         if (CONFIG_INSTANCE == null) {
-            GTNHCustomizer.LOGGER.error("Cannot load configuration!");
-            GTNHCustomizer.LOGGER
+            GTNHCustomizer.getLogger().error("Cannot load configuration!");
+            GTNHCustomizer.getLogger()
                 .error("Configuration has not been initialized yet!");
             return;
         }
         CONFIG_INSTANCE.load();
         if (!CONFIG_INSTANCE.getLoadedConfigVersion()
             .equals(ConfigConstants.CONFIG_VERSION)) {
-            GTNHCustomizer.LOGGER.warn("Your configuration is out of date!");
-            GTNHCustomizer.LOGGER.warn(
+            GTNHCustomizer.getLogger()
+                .warn("Your configuration is out of date!");
+            GTNHCustomizer.getLogger().warn(
                 "We're running version '{}' but you have version '{}'",
                 ConfigConstants.CONFIG_VERSION,
                 CONFIG_INSTANCE.getLoadedConfigVersion());
-            GTNHCustomizer.LOGGER.warn("Attempting to migrate!");
+            GTNHCustomizer.getLogger().warn("Attempting to migrate!");
             try {
                 applyConfigMigrations(CONFIG_INSTANCE.getLoadedConfigVersion(),
                     ConfigConstants.CONFIG_VERSION, CONFIG_INSTANCE);
                 save();
             } catch (NoSuchElementException t) {
-                GTNHCustomizer.LOGGER
+                GTNHCustomizer.getLogger()
                     .info(
                         "No migrations available from version '{}' to version '{}', assuming migration is not required!",
                         CONFIG_INSTANCE.getLoadedConfigVersion(),
                         ConfigConstants.CONFIG_VERSION);
             } catch (Throwable t) {
-                GTNHCustomizer.LOGGER
+                GTNHCustomizer.getLogger()
                     .warn(
                         "Could not migrate configuration from version '{}' to version '{}'!",
                         CONFIG_INSTANCE.getLoadedConfigVersion(),
                         ConfigConstants.CONFIG_VERSION);
-                GTNHCustomizer.LOGGER
+                GTNHCustomizer.getLogger()
                     .warn(
                         "Here's a stack trace for you to use if you want to file a bug report about migrations failing:");
-                GTNHCustomizer.LOGGER
+                GTNHCustomizer.getLogger()
                     .warn(t);
-                GTNHCustomizer.LOGGER
+                GTNHCustomizer.getLogger()
                     .warn(
                         "Any customizations you've made are probably about to get nuked!");
                 File backupLocation = new File(String.format("%s.bak",
                     CONFIG_INSTANCE.getConfigFile()
                         .getAbsolutePath()));
-                GTNHCustomizer.LOGGER
+                GTNHCustomizer.getLogger()
                     .warn(
                         "Copying your current configuration into '{}' as a backup...",
                         backupLocation.getAbsolutePath());
@@ -507,18 +508,18 @@ public class Config {
                         backupLocation.toPath(),
                         StandardCopyOption.REPLACE_EXISTING);
                 } catch (Throwable tt) {
-                    GTNHCustomizer.LOGGER
+                    GTNHCustomizer.getLogger()
                         .warn(
                             "Failed to generate a backup of your current configuration!");
-                    GTNHCustomizer.LOGGER
+                    GTNHCustomizer.getLogger()
                         .warn(
                             "Here's a stack trace for you to use if you want to diagnose what happened:");
-                    GTNHCustomizer.LOGGER
+                    GTNHCustomizer.getLogger()
                         .warn(tt);
-                    GTNHCustomizer.LOGGER
+                    GTNHCustomizer.getLogger()
                         .warn(
                             "Please do NOT file a bug report about failing to create a backup, this is almost certainly NOT the mod developer's fault!");
-                    GTNHCustomizer.LOGGER
+                    GTNHCustomizer.getLogger()
                         .warn(
                             "Proceeding anyway, sorry!");
                 }
@@ -664,8 +665,8 @@ public class Config {
      */
     public static void save() {
         if (CONFIG_INSTANCE == null) {
-            GTNHCustomizer.LOGGER.error("Cannot save configuration!");
-            GTNHCustomizer.LOGGER
+            GTNHCustomizer.getLogger().error("Cannot save configuration!");
+            GTNHCustomizer.getLogger()
                 .error("Configuration has not been initialized yet!");
             return;
         }

--- a/src/main/java/com/glektarssza/gtnh_customizer/mixins/late/serverutilities/TextBoxMixin.java
+++ b/src/main/java/com/glektarssza/gtnh_customizer/mixins/late/serverutilities/TextBoxMixin.java
@@ -1,12 +1,12 @@
 package com.glektarssza.gtnh_customizer.mixins.late.serverutilities;
 
-import org.lwjgl.input.Keyboard;
-
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import com.glektarssza.gtnh_customizer.KeyBindings;
 
 import serverutils.lib.gui.TextBox;
 
@@ -30,10 +30,19 @@ public class TextBoxMixin {
         TextBox self = (TextBox) (Object) this;
         if (!self.isFocused()) {
             return;
-        } else if (keyCode == Keyboard.KEY_NUMPADENTER) {
+        }
+        if (keyCode == KeyBindings.ACCEPT_NBT_VALUE_CHANGE.getKeyCode()
+            || keyCode == KeyBindings.ACCEPT_NBT_VALUE_CHANGE_ALT
+                .getKeyCode()) {
             if (validText) {
                 self.setFocused(false);
                 self.onEnterPressed();
+            }
+            cir.setReturnValue(true);
+        }
+        if (keyCode == KeyBindings.CANCEL_NBT_VALUE_CHANGE.getKeyCode()) {
+            if (validText) {
+                self.closeGui(false);
             }
             cir.setReturnValue(true);
         }

--- a/src/main/java/com/glektarssza/gtnh_customizer/mixins/late/xaeros/client/WaypointsManagerMixins.java
+++ b/src/main/java/com/glektarssza/gtnh_customizer/mixins/late/xaeros/client/WaypointsManagerMixins.java
@@ -57,7 +57,7 @@ public class WaypointsManagerMixins {
                 int dimId = Integer.parseInt(dimensionId.substring(4));
                 dimensionId = String.format("%d", dimId);
             } catch (NumberFormatException t) {
-                GTNHCustomizer.LOGGER.warn(
+                GTNHCustomizer.getLogger().warn(
                     "Non-integer dimension ID '{}', teleport command is probably going to fail!",
                     dimensionId.substring(4));
             }
@@ -99,7 +99,8 @@ public class WaypointsManagerMixins {
         }
         matcher.appendTail(teleportCommandBuffer);
         if (Config.getVerboseLoggingEnabled()) {
-            GTNHCustomizer.LOGGER.debug("Final Xaero's teleport command: {}",
+            GTNHCustomizer.getLogger().debug(
+                "Final Xaero's teleport command: {}",
                 teleportCommandBuffer.toString());
         }
         player.sendChatMessage(teleportCommandBuffer.toString());

--- a/src/main/resources/assets/gtnh_customizer/lang/en_US.lang
+++ b/src/main/resources/assets/gtnh_customizer/lang/en_US.lang
@@ -71,3 +71,13 @@ gtnh_customizer.commands.extinguish.error.volume_too_large=Cannot process that m
 gtnh_customizer.commands.extinguish.info.success=Successfully extinguished flame(s)!
 gtnh_customizer.commands.extinguish.info.admin_notify.radius=Player '%s' extinguished flames in a '%s' block radius.
 gtnh_customizer.commands.extinguish.info.admin_notify.zone=Player '%s' extinguished flames from '%s %s %s' to '%s %s %s'.
+
+# Keybinds
+key.categories.gtnh_customizer=GTNH Customizer
+gtnh_customizer.keybindings.serverutilities.delete_nbt_tag=Delete NBT Tag
+gtnh_customizer.keybindings.serverutilities.accept_nbt_edits=Accept NBT Edits
+gtnh_customizer.keybindings.serverutilities.accept_nbt_edits_alt=Accept NBT Edits (Alt)
+gtnh_customizer.keybindings.serverutilities.cancel_nbt_edits=Cancel NBT Edits
+gtnh_customizer.keybindings.serverutilities.accept_nbt_value_change=Accept NBT Value Change
+gtnh_customizer.keybindings.serverutilities.accept_nbt_value_change_alt=Accept NBT Value Change (Alt)
+gtnh_customizer.keybindings.serverutilities.cancel_nbt_value_change=Cancel NBT Value Change


### PR DESCRIPTION
* Support key bindings for some `/nbtedit` stuff.
* Support delete shortcut key for `/nbtedit` command to delete NBT tags on object being edited.
* Small refactor to logger stuff.
* Updated Forge update manifest.