### PR TITLE
[Bug Fix] Fixed `/extinguish` command erroring during `/help` calls

### DIFF
--- a/src/main/java/com/glektarssza/gtnh_customizer/commands/ExtinguishCommand.java
+++ b/src/main/java/com/glektarssza/gtnh_customizer/commands/ExtinguishCommand.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.List;
 
 import net.minecraft.block.Block;
+import net.minecraft.client.resources.I18n;
 import net.minecraft.command.CommandBase;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.command.WrongUsageException;
@@ -60,11 +61,11 @@ public class ExtinguishCommand extends CommandBase {
      */
     @Override
     public String getCommandUsage(ICommandSender sender) {
-        return new ChatComponentTranslation(
+        return I18n.format(
             "gtnh_customizer.commands.extinguish.usage", new Object[] {
                 String.format("%d",
                     GTNHCustomizer.getProxy().getViewDistanceBlocks())
-            }).getFormattedText();
+            });
     }
 
     /**


### PR DESCRIPTION
Use the `I18n` class to do translations, not `ChatComponent`. That's a silly way to do it.