### PR TITLE
[Chore] Update VSCode extension list

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -7,7 +7,6 @@
         "redhat.java",
         "vscjava.vscode-java-dependency",
         "vscjava.vscode-java-debug",
-        "vscjava.vscode-java-test",
         "vscjava.vscode-gradle"
     ],
     "unwantedRecommendations": ["vscjava.vscode-java-pack"]

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -9,5 +9,6 @@
         "vscjava.vscode-java-debug",
         "vscjava.vscode-java-test",
         "vscjava.vscode-gradle"
-    ]
+    ],
+    "unwantedRecommendations": ["vscjava.vscode-java-pack"]
 }


### PR DESCRIPTION
* Don't need Java testing extension (for now).
* Explicitly ignore the Microsoft Java extension pack (ID `vscjava.vscode-java-pack`) as it installs an extension now currently enables Copilot even if it's disabled by the end user.
  * This is being worked on. See microsoft/vscode-java-pack#1497.